### PR TITLE
Show unmapped noko records

### DIFF
--- a/src/components/WeekEditor.vue
+++ b/src/components/WeekEditor.vue
@@ -24,13 +24,12 @@ const emits = defineEmits<{
 const applicationStore = useApplicationStore();
 const nokoClient = applicationStore.getNokoClient();
 
-const timeTableEntries = ref<TimeTableEntry[]>(
-  mapToTimeTableEntries(
-    props.dateRange,
-    applicationStore.categories,
-    props.entries,
-  ),
+const mappedEntries = mapToTimeTableEntries(
+  props.dateRange,
+  applicationStore.categories,
+  props.entries,
 );
+const timeTableEntries = ref<TimeTableEntry[]>(mappedEntries.entries);
 const inputValues = ref<string[]>(
   timeTableEntries.value.map((v) => toHoursMinutesNotation(v.inputMinutes)),
 );
@@ -286,6 +285,25 @@ const onSubmit = async () => {
                   <span class="pl-1">
                     {{ categorySummaries[categoryIndex] }}
                   </span>
+                </div>
+              </td>
+            </tr>
+
+            <tr class="text-gray-500" v-if="mappedEntries.unmappedEntries.length > 0">
+              <td>Overige</td>
+
+              <td
+                v-for="(_, index) in loggableDays"
+                class="text-center"
+              >
+                <div class="min-h-6">
+                  {{ toHoursMinutesNotation(mappedEntries.unmappedEntries[index].inputMinutes) }}
+                </div>
+              </td>
+
+              <td class="text-center">
+                <div class="min-h-6" style="min-width: 65px">
+                  {{ toHoursMinutesNotation(mappedEntries.unmappedEntries.reduce<number>((acc, cur) => acc + cur.inputMinutes, 0)) }}
                 </div>
               </td>
             </tr>

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,94 +1,69 @@
+import { DateRange } from "@/date";
 import { toShortIsoDate } from "@/format";
-import { INokoPostEntryRequest, INokoPutEntryRequest } from "@/requests";
+import { INokoPostEntryRequest } from "@/requests";
 import { INokoGetEntryResponse } from "@/responses";
-import { TagToCategoryMapping, TimeTableEntry, loggableDays } from "@/types";
+import { Category, TimeTableEntry, loggableDays } from "@/types";
 
-type DayAndTagMapping = {
-  date: string;
-  day: string;
-  projectId: number;
-  nokoTags: string[];
-  category: string;
-  archived: boolean;
-};
-
-type NokoTimeTableMapping = {
-  date: string;
-  day: string;
-  projectId: number;
-  nokoTags: string[];
-  category: string;
-  archived: boolean;
-  entries: INokoGetEntryResponse[];
-  minutes: number;
-};
-
-type TimeTableDelta = {
+type DeltaInNokoApiCalls = {
   creates: INokoPostEntryRequest[];
-  updates: { id: number; body: INokoPutEntryRequest }[];
   idsToDelete: number[];
 };
 type DayCategoryDelta = {
   create: INokoPostEntryRequest | null;
-  update: { id: number; body: INokoPutEntryRequest } | null;
   idsToDelete: number[];
 };
 
-export function convertToTimeTableInput(
-  weekDays: Date[],
-  categoryMapping: TagToCategoryMapping[],
-  entries: INokoGetEntryResponse[],
-): TimeTableEntry[] {
-  return getNokoToTimeTableMapping(weekDays, categoryMapping, entries).map(
-    (m) => ({ category: m.category, day: m.day, minutes: m.minutes }),
-  );
-}
-
 export function getNokoCallsForDelta(
-  weekDays: Date[],
-  categoryMapping: TagToCategoryMapping[],
-  nokoEntries: INokoGetEntryResponse[],
   timeTableEntries: TimeTableEntry[],
-): TimeTableDelta {
-  const preUserInputMapping = getNokoToTimeTableMapping(
-    weekDays,
-    categoryMapping,
-    nokoEntries,
-  );
-
+  nokoEntries: INokoGetEntryResponse[],
+): DeltaInNokoApiCalls {
   const categoryResultsPerDay: DayCategoryDelta[] = [];
-  for (let i = 0; i < preUserInputMapping.length; ++i) {
-    const original = preUserInputMapping[i];
-    if (original.archived) {
+  timeTableEntries.forEach((entry) => {
+    if (entry.category.readonly) {
       console.debug(
-        `Ignoring any changes made to the archived category ${original.category}.`,
+        `Ignoring any changes made to the readonly category ${entry.category}.`,
       );
-      continue;
+      return;
     }
 
-    const userInput = timeTableEntries.find(
-      (t) => t.category === original.category && t.day === original.day,
+    const entryDateAsIsoDate = toShortIsoDate(entry.date);
+    const entryOriginalNokoEntries = nokoEntries.filter(
+      (ne) =>
+        ne.date === entryDateAsIsoDate && isForCategory(ne, entry.category),
     );
-    if (userInput) {
-      categoryResultsPerDay.push(getDayDelta(original, userInput));
-    } else {
-      console.debug(
-        `Time table entry for project ${original.category} on ${original.day} seems to be missing?`,
-      );
-    }
-  }
 
-  const result: TimeTableDelta = {
+    const originalMinutes = entryOriginalNokoEntries.reduce<number>(
+      (sum, current) => sum + current.minutes,
+      0,
+    );
+    if (originalMinutes === entry.inputMinutes) {
+      console.debug(
+        `No changes in minutes for ${entry.category.name} on ${entryDateAsIsoDate}`,
+      );
+    } else {
+      let createRequest: INokoPostEntryRequest | null = null;
+      if (entry.inputMinutes > 0) {
+        createRequest = {
+          date: entryDateAsIsoDate,
+          description: entry.category.nokoTags.join(" "),
+          minutes: entry.inputMinutes,
+          project_id: entry.category.projectId,
+        };
+      }
+      categoryResultsPerDay.push({
+        create: createRequest,
+        idsToDelete: entryOriginalNokoEntries.map((ne) => ne.id),
+      });
+    }
+  });
+
+  const result: DeltaInNokoApiCalls = {
     creates: [],
-    updates: [],
     idsToDelete: [],
   };
   categoryResultsPerDay.forEach((dayResult) => {
     if (dayResult.create != null) {
       result.creates.push(dayResult.create);
-    }
-    if (dayResult.update != null) {
-      result.updates.push(dayResult.update);
     }
     if (dayResult.idsToDelete.length > 0) {
       dayResult.idsToDelete.forEach((id) => result.idsToDelete.push(id));
@@ -97,117 +72,73 @@ export function getNokoCallsForDelta(
   return result;
 }
 
-function getDayDelta(
-  original: NokoTimeTableMapping,
-  userInput: TimeTableEntry,
-): DayCategoryDelta {
-  // No changes
-  if (original.minutes === userInput.minutes) {
-    return { create: null, update: null, idsToDelete: [] };
-  }
-
-  // User removed all time
-  if (userInput.minutes <= 0) {
-    return {
-      create: null,
-      update: null,
-      idsToDelete: original.entries.map((e) => e.id),
-    };
-  }
-
-  const description = original.nokoTags.join(" ");
-  // User created a first entry
-  if (original.entries.length === 0) {
-    return {
-      create: {
-        date: original.date,
-        minutes: userInput.minutes,
-        project_id: original.projectId,
-        description,
-      },
-      update: null,
-      idsToDelete: [],
-    };
-  }
-
-  // TODO Maybe make this less destructive? It deletes all but one entry for the same tag combination
-  return {
-    create: null,
-    update: {
-      id: original.entries[0].id,
-      body: {
-        date: original.date,
-        minutes: userInput.minutes,
-        project_id: original.projectId,
-        description,
-      },
-    },
-    idsToDelete: original.entries.slice(1).map((e) => e.id),
-  };
-}
-
-function getNokoToTimeTableMapping(
-  weekDays: Date[],
-  categoryMapping: TagToCategoryMapping[],
-  entries: INokoGetEntryResponse[],
-): NokoTimeTableMapping[] {
-  const dayAndTagMapping = getDayAndTagMapping(weekDays, categoryMapping);
-  return dayAndTagMapping.map((dtm) => {
-    const filteredEntries = entries.filter(
-      (e) =>
-        dtm.category &&
-        e.date === dtm.date &&
-        e.project.id === dtm.projectId &&
-        dtm.nokoTags.length == e.tags.length &&
-        dtm.nokoTags.every((mt) =>
-          e.tags.some((et) => et.formatted_name === mt),
-        ),
-    );
-
-    return {
-      date: dtm.date,
-      day: dtm.day,
-      projectId: dtm.projectId,
-      nokoTags: dtm.nokoTags,
-      category: dtm.category,
-      archived: dtm.archived,
-      entries: filteredEntries,
-      minutes: filteredEntries.reduce<number>(
-        (ec, entry) => ec + entry.minutes,
-        0,
-      ),
-    };
-  });
-}
-
-function getDayAndTagMapping(
-  weekDays: Date[],
-  categoryMapping: TagToCategoryMapping[],
-): DayAndTagMapping[] {
-  if (weekDays.length !== loggableDays.length) {
-    throw new Error(
-      "The week days should match the loggable days as they are assumed to be a 1:1 mapping",
+export function mapToTimeTableEntries(
+  dateRange: DateRange,
+  categories: Category[],
+  nokoEntries: INokoGetEntryResponse[],
+): TimeTableEntry[] {
+  if (dateRange.dates.length !== loggableDays.length) {
+    throw Error(
+      `Expected the date range to be 1 week, but it was ${dateRange.dates.length} day(s)`,
     );
   }
-
-  const dayToDateMapping = weekDays.map((d, index) => ({
-    date: toShortIsoDate(d),
-    day: loggableDays[index],
-  }));
-
-  const results: DayAndTagMapping[] = [];
-  for (let i = 0; i < dayToDateMapping.length; ++i) {
-    for (let j = 0; j < categoryMapping.length; ++j) {
-      results.push({
-        day: dayToDateMapping[i].day,
-        date: dayToDateMapping[i].date,
-        projectId: categoryMapping[j].projectId,
-        nokoTags: categoryMapping[j].nokoTags,
-        category: categoryMapping[j].name,
-        archived: categoryMapping[j].archived,
-      });
+  for (let i = 0; i < dateRange.dates.length; ++i) {
+    for (let j = i + 1; j < dateRange.dates.length; ++j) {
+      if (dateRange.dates[i].getTime() >= dateRange.dates[j].getTime()) {
+        throw Error(
+          "Expected the date range dates to be sorted ascendingly and unique",
+        );
+      }
     }
   }
 
-  return results;
+  const timeTableEntries: TimeTableEntry[] = [];
+  categories.forEach((category) => {
+    dateRange.dates.forEach((date, dateIndex) => {
+      const entryIsoDate = toShortIsoDate(date);
+      const matchingNokoEntries = nokoEntries.filter(
+        (ne) => ne.date === entryIsoDate && isForCategory(ne, category),
+      );
+      const initialMinutes = matchingNokoEntries.reduce<number>(
+        (acc, current) => acc + current.minutes,
+        0,
+      );
+      timeTableEntries.push({
+        date: date,
+        category: category,
+        dayName: loggableDays[dateIndex],
+        initialMinutes: initialMinutes,
+        inputMinutes: initialMinutes,
+      });
+    });
+  });
+
+  return timeTableEntries;
+}
+
+function isForCategory(
+  nokoEntry: INokoGetEntryResponse,
+  category: Category,
+): boolean {
+  return (
+    nokoEntry.project.id === category.projectId &&
+    areTagsEqual(nokoEntry, category)
+  );
+}
+
+function areTagsEqual(
+  nokoEntry: INokoGetEntryResponse,
+  category: Category,
+): boolean {
+  if (nokoEntry.tags.length !== category.nokoTags.length) {
+    return false;
+  }
+
+  for (let i = 0; i < nokoEntry.tags.length; ++i) {
+    if (!category.nokoTags.includes(nokoEntry.tags[i].formatted_name)) {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,9 +18,14 @@ export type Category = {
 };
 
 export type TimeTableEntry = {
-  category: Category;
+  category: TimeTableEntryCategory;
   dayName: LoggableDay;
   date: Date;
   initialMinutes: number;
   inputMinutes: number;
 };
+
+export type TimeTableEntryCategory = {
+  projectId?: number;
+  nokoTags?: string[];
+} & Omit<Category, "projectId" | "nokoTags">;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,16 +9,18 @@ export const loggableDays: string[] = [
 ] as const;
 export type LoggableDay = (typeof loggableDays)[number];
 
-export type TagToCategoryMapping = {
+export type Category = {
   order: number;
-  archived: boolean;
+  readonly: boolean;
   projectId: number;
   nokoTags: string[];
   name: string;
 };
 
 export type TimeTableEntry = {
-  category: string;
-  day: LoggableDay;
-  minutes: number;
+  category: Category;
+  dayName: LoggableDay;
+  date: Date;
+  initialMinutes: number;
+  inputMinutes: number;
 };

--- a/src/views/SetupCategories.vue
+++ b/src/views/SetupCategories.vue
@@ -9,7 +9,7 @@ import { useRouter } from "vue-router";
 type CategoryEntry = {
   id: number;
   order: string;
-  archived: boolean;
+  readonly: boolean;
   projectId: number;
   nokoTags: string[];
   name: string;
@@ -37,16 +37,14 @@ const toAdd = reactive({
 });
 let nextCategoryId = 0;
 const values: CategoryEntry[] = reactive(
-  applicationStore.categories
-    .map((c, index) => ({
-      id: nextCategoryId++,
-      archived: c.archived,
-      order: index.toString(),
-      projectId: c.projectId,
-      nokoTags: c.nokoTags.slice(),
-      name: c.name,
-    }))
-    .sort((a, b) => parseInt(a.order) - parseInt(b.order)),
+  applicationStore.categories.map((c, index) => ({
+    id: nextCategoryId++,
+    readonly: c.readonly,
+    order: index.toString(),
+    projectId: c.projectId,
+    nokoTags: c.nokoTags.slice(),
+    name: c.name,
+  })),
 );
 
 const getProjectName = (id: number): string => {
@@ -112,7 +110,7 @@ const onAddCategory = () => {
 
   values.push({
     id: nextCategoryId++,
-    archived: false,
+    readonly: false,
     order: values.length.toString(),
     projectId,
     nokoTags: toAdd.nokoTags,
@@ -155,15 +153,13 @@ const onSubmit = async () => {
       return;
     }
 
-    applicationStore.categories = values
-      .map((v) => ({
-        order: parseInt(v.order),
-        archived: v.archived,
-        projectId: v.projectId,
-        nokoTags: v.nokoTags,
-        name: v.name,
-      }))
-      .sort((a, b) => a.order - b.order);
+    applicationStore.categories = values.map((v) => ({
+      order: parseInt(v.order),
+      readonly: v.readonly,
+      projectId: v.projectId,
+      nokoTags: v.nokoTags,
+      name: v.name,
+    }));
     applicationStore.peristCategories();
 
     await router.push("/");
@@ -206,7 +202,7 @@ const onSubmit = async () => {
               <td>{{ getProjectName(value.projectId) }}</td>
               <td>{{ value.nokoTags.join(", ") }}</td>
               <td>
-                <KeepiCheckbox v-model="value.archived" type="checkbox" />
+                <KeepiCheckbox v-model="value.readonly" type="checkbox" />
               </td>
               <td>
                 <button
@@ -324,7 +320,7 @@ const onSubmit = async () => {
               <!-- todo add tag suggestions here -->
             </td>
             <td>
-              <!-- Adding archived tags is not in scope for now -->
+              <!-- Adding readonly tags is not in scope for now -->
             </td>
             <td class="align-top">
               <KeepiButton

--- a/test/transformer.test.ts
+++ b/test/transformer.test.ts
@@ -1,14 +1,254 @@
+import { DateRange } from "@/date";
 import { toShortIsoDate } from "@/format";
 import { INokoGetEntryResponse } from "@/responses";
-import { convertToTimeTableInput, getNokoCallsForDelta } from "@/transformer";
-import { TagToCategoryMapping, TimeTableEntry, loggableDays } from "@/types";
+import { mapToTimeTableEntries, getNokoCallsForDelta } from "@/transformer";
+import { Category, TimeTableEntry, loggableDays } from "@/types";
 import { describe, expect, test } from "vitest";
 
 describe("transformer", () => {
-  describe("convertToTimeTableInput", () => {
+  describe("mapToTimeTableEntries", () => {
+    test("date range should be sorted ascendingly", () => {
+      expect(() =>
+        mapToTimeTableEntries(
+          {
+            dates: [
+              new Date("2024-01-23T00:00:00Z"), // tuesday
+              new Date("2024-01-22T00:00:00Z"), // monday
+              new Date("2024-01-24T00:00:00Z"), // wednesday
+              new Date("2024-01-25T00:00:00Z"), // thursday
+              new Date("2024-01-26T00:00:00Z"), // friday
+              new Date("2024-01-27T00:00:00Z"), // saturday
+              new Date("2024-01-28T00:00:00Z"), // sunday
+            ],
+            weekNumber: 4,
+            year: 2024,
+          },
+          getTestTagToCategoryMappings(),
+          [],
+        ),
+      ).toThrowError(
+        "Expected the date range dates to be sorted ascendingly and unique",
+      );
+    });
+
+    test("date range should 1 week", () => {
+      expect(() =>
+        mapToTimeTableEntries(
+          {
+            dates: [
+              new Date("2024-01-22T00:00:00Z"), // monday
+              new Date("2024-01-23T00:00:00Z"), // tuesday
+              new Date("2024-01-24T00:00:00Z"), // wednesday
+              new Date("2024-01-25T00:00:00Z"), // thursday
+              new Date("2024-01-26T00:00:00Z"), // friday
+              new Date("2024-01-27T00:00:00Z"), // saturday
+            ],
+            weekNumber: 4,
+            year: 2024,
+          },
+          getTestTagToCategoryMappings(),
+          [],
+        ),
+      ).toThrowError(
+        "Expected the date range to be 1 week, but it was 6 day(s)",
+      );
+    });
+
+    test("date range should contain unique dates", () => {
+      expect(() =>
+        mapToTimeTableEntries(
+          {
+            dates: [
+              new Date("2024-01-22T00:00:00Z"), // monday
+              new Date("2024-01-23T00:00:00Z"), // tuesday
+              new Date("2024-01-23T00:00:00Z"), // tuesday
+              new Date("2024-01-25T00:00:00Z"), // thursday
+              new Date("2024-01-26T00:00:00Z"), // friday
+              new Date("2024-01-27T00:00:00Z"), // saturday
+              new Date("2024-01-28T00:00:00Z"), // sunday
+            ],
+            weekNumber: 4,
+            year: 2024,
+          },
+          getTestTagToCategoryMappings(),
+          [],
+        ),
+      ).toThrowError(
+        "Expected the date range dates to be sorted ascendingly and unique",
+      );
+    });
+
+    test("entries should be sorted by category input order then by date ascending", () => {
+      const result = mapToTimeTableEntries(
+        getTestDateRange(),
+        getTestTagToCategoryMappings(),
+        [
+          {
+            id: 5004,
+            date: "2024-01-24", // wednesday
+            user: {
+              id: 9000,
+            },
+            minutes: 60, // 1 hour
+            description: "#Presentation",
+            project: {
+              id: 1,
+            },
+            tags: [
+              {
+                id: 4001,
+                formatted_name: "#Presentation",
+              },
+            ],
+          },
+          {
+            id: 5002,
+            date: "2024-01-23", // tuesday
+            user: {
+              id: 9000,
+            },
+            minutes: 480, // 8 hours
+            description: "#Development",
+            project: {
+              id: 1,
+            },
+            tags: [
+              {
+                id: 4000,
+                formatted_name: "#Development",
+              },
+            ],
+          },
+          {
+            id: 5001,
+            date: "2024-01-22", // monday
+            user: {
+              id: 9000,
+            },
+            minutes: 480, // 8 hours
+            description: "#Development",
+            project: {
+              id: 1,
+            },
+            tags: [
+              {
+                id: 4000,
+                formatted_name: "#Development",
+              },
+            ],
+          },
+          {
+            id: 5005,
+            date: "2024-01-25", // thursday
+            user: {
+              id: 9000,
+            },
+            minutes: 480, // 8 hours
+            description: "#National-Holiday",
+            project: {
+              id: 2,
+            },
+            tags: [
+              {
+                id: 4002,
+                formatted_name: "#National-Holiday",
+              },
+            ],
+          },
+          {
+            id: 5006,
+            date: "2024-01-26", // friday
+            user: {
+              id: 9000,
+            },
+            minutes: 480, // 8 hours
+            description: "#Development",
+            project: {
+              id: 1,
+            },
+            tags: [
+              {
+                id: 4000,
+                formatted_name: "#Development",
+              },
+            ],
+          },
+        ],
+      );
+
+      expect(result.length).toBe(28);
+
+      expect(result[0].category.name).toBe("Development");
+      expect(result[1].category.name).toBe("Development");
+      expect(result[2].category.name).toBe("Development");
+      expect(result[3].category.name).toBe("Development");
+      expect(result[4].category.name).toBe("Development");
+      expect(result[5].category.name).toBe("Development");
+      expect(result[6].category.name).toBe("Development");
+
+      expect(result[7].category.name).toBe("Vacation");
+      expect(result[8].category.name).toBe("Vacation");
+      expect(result[9].category.name).toBe("Vacation");
+      expect(result[10].category.name).toBe("Vacation");
+      expect(result[11].category.name).toBe("Vacation");
+      expect(result[12].category.name).toBe("Vacation");
+      expect(result[13].category.name).toBe("Vacation");
+
+      expect(result[14].category.name).toBe("National holiday");
+      expect(result[15].category.name).toBe("National holiday");
+      expect(result[16].category.name).toBe("National holiday");
+      expect(result[17].category.name).toBe("National holiday");
+      expect(result[18].category.name).toBe("National holiday");
+      expect(result[19].category.name).toBe("National holiday");
+      expect(result[20].category.name).toBe("National holiday");
+
+      expect(result[21].category.name).toBe("Presentation");
+      expect(result[22].category.name).toBe("Presentation");
+      expect(result[23].category.name).toBe("Presentation");
+      expect(result[24].category.name).toBe("Presentation");
+      expect(result[25].category.name).toBe("Presentation");
+      expect(result[26].category.name).toBe("Presentation");
+      expect(result[27].category.name).toBe("Presentation");
+
+      expect(toShortIsoDate(result[0].date)).toBe("2024-01-22");
+      expect(toShortIsoDate(result[7].date)).toBe("2024-01-22");
+      expect(toShortIsoDate(result[14].date)).toBe("2024-01-22");
+      expect(toShortIsoDate(result[21].date)).toBe("2024-01-22");
+
+      expect(toShortIsoDate(result[1].date)).toBe("2024-01-23");
+      expect(toShortIsoDate(result[8].date)).toBe("2024-01-23");
+      expect(toShortIsoDate(result[15].date)).toBe("2024-01-23");
+      expect(toShortIsoDate(result[22].date)).toBe("2024-01-23");
+
+      expect(toShortIsoDate(result[2].date)).toBe("2024-01-24");
+      expect(toShortIsoDate(result[9].date)).toBe("2024-01-24");
+      expect(toShortIsoDate(result[16].date)).toBe("2024-01-24");
+      expect(toShortIsoDate(result[23].date)).toBe("2024-01-24");
+
+      expect(toShortIsoDate(result[3].date)).toBe("2024-01-25");
+      expect(toShortIsoDate(result[10].date)).toBe("2024-01-25");
+      expect(toShortIsoDate(result[17].date)).toBe("2024-01-25");
+      expect(toShortIsoDate(result[24].date)).toBe("2024-01-25");
+
+      expect(toShortIsoDate(result[4].date)).toBe("2024-01-26");
+      expect(toShortIsoDate(result[11].date)).toBe("2024-01-26");
+      expect(toShortIsoDate(result[18].date)).toBe("2024-01-26");
+      expect(toShortIsoDate(result[25].date)).toBe("2024-01-26");
+
+      expect(toShortIsoDate(result[5].date)).toBe("2024-01-27");
+      expect(toShortIsoDate(result[12].date)).toBe("2024-01-27");
+      expect(toShortIsoDate(result[19].date)).toBe("2024-01-27");
+      expect(toShortIsoDate(result[26].date)).toBe("2024-01-27");
+
+      expect(toShortIsoDate(result[6].date)).toBe("2024-01-28");
+      expect(toShortIsoDate(result[13].date)).toBe("2024-01-28");
+      expect(toShortIsoDate(result[20].date)).toBe("2024-01-28");
+      expect(toShortIsoDate(result[27].date)).toBe("2024-01-28");
+    });
+
     test("average workweek scenario should be mapped correctly", () => {
-      const result = convertToTimeTableInput(
-        getTestWeekdays(),
+      const result = mapToTimeTableEntries(
+        getTestDateRange(),
         getTestTagToCategoryMappings(),
         getAverageWorkweekEntries(),
       );
@@ -41,8 +281,8 @@ describe("transformer", () => {
     });
 
     test("partial average workweek scenario should be mapped correctly", () => {
-      const result = convertToTimeTableInput(
-        getTestWeekdays(),
+      const result = mapToTimeTableEntries(
+        getTestDateRange(),
         getTestTagToCategoryMappings(),
         // Only include monday until wednesday
         getAverageWorkweekEntries().filter((e) => e.date < "2024-01-25"),
@@ -76,8 +316,8 @@ describe("transformer", () => {
     });
 
     test("vacation scenario should be mapped correctly", () => {
-      const result = convertToTimeTableInput(
-        getTestWeekdays(),
+      const result = mapToTimeTableEntries(
+        getTestDateRange(),
         getTestTagToCategoryMappings(),
         getVacationWeekEntries(),
       );
@@ -110,8 +350,8 @@ describe("transformer", () => {
     });
 
     test("ignores unmapped entries", () => {
-      const result = convertToTimeTableInput(
-        getTestWeekdays(),
+      const result = mapToTimeTableEntries(
+        getTestDateRange(),
         getTestTagToCategoryMappings(),
         [
           {
@@ -204,12 +444,12 @@ describe("transformer", () => {
     });
 
     function expectToHaveTimeTableEntriesForProjectWeekDays(
-      category: string,
+      categoryName: string,
       timeTableEntries: TimeTableEntry[],
       minutesPerWeekDay: number[],
     ) {
       const categoryEntries = timeTableEntries.filter(
-        (r) => r.category === category,
+        (r) => r.category.name === categoryName,
       );
       expect(categoryEntries.length).toBe(7);
 
@@ -220,36 +460,44 @@ describe("transformer", () => {
       }
       if (categoryEntries.length != loggableDays.length) {
         throw Error(
-          `Unexpected number of entries for ${category}. Expected ${loggableDays.length} (1 per workday) but received ${categoryEntries.length}`,
+          `Unexpected number of entries for ${categoryName}. Expected ${loggableDays.length} (1 per workday) but received ${categoryEntries.length}`,
         );
       }
 
       for (let i = 0; i < loggableDays.length; ++i) {
-        expect(categoryEntries).toContainEqual({
-          category,
-          day: loggableDays[i],
-          minutes: minutesPerWeekDay[i],
-        });
+        const match = categoryEntries.find(
+          (e) =>
+            e.category.name === categoryName && e.dayName === loggableDays[i],
+        );
+        if (match == null) {
+          throw Error(
+            `The mapped entries dit not contain an entry for category ${categoryName} and ${loggableDays[i]}`,
+          );
+        }
+
+        expect(match.inputMinutes).toBe(minutesPerWeekDay[i]);
       }
     }
   });
 
-  // If these test fail be sure to first check if the convertToTimeTableInput
+  // If these test fail be sure to first check if the mapToTimeTableEntries
   // tests pass as it is used to create scenarios as input for these tests
   describe("getNokoCallsForDelta", () => {
     test("empty workweek to complete workweek should produce expected delta", () => {
-      const weekDays = getTestWeekdays();
       const categoryMapping = getTestTagToCategoryMappings();
       const entries = getAverageWorkweekEntries();
 
       // The complete average workweek scenario
-      const input = convertToTimeTableInput(weekDays, categoryMapping, entries);
+      const input = mapToTimeTableEntries(
+        getTestDateRange(),
+        categoryMapping,
+        entries,
+      );
 
-      const result = getNokoCallsForDelta(weekDays, categoryMapping, [], input);
+      const result = getNokoCallsForDelta(input, []);
 
       expect(result.creates.length).toBe(6);
       expect(result.idsToDelete.length).toBe(0);
-      expect(result.updates.length).toBe(0);
 
       expect(result.creates).toContainEqual({
         date: "2024-01-22",
@@ -290,24 +538,24 @@ describe("transformer", () => {
     });
 
     test("partial workweek to complete workweek should produce expected delta", () => {
-      const weekDays = getTestWeekdays();
       const categoryMapping = getTestTagToCategoryMappings();
       const entries = getAverageWorkweekEntries();
 
       // The complete average workweek scenario
-      const input = convertToTimeTableInput(weekDays, categoryMapping, entries);
+      const input = mapToTimeTableEntries(
+        getTestDateRange(),
+        categoryMapping,
+        entries,
+      );
 
       const result = getNokoCallsForDelta(
-        weekDays,
-        categoryMapping,
+        input,
         // Only include monday until wednesday
         entries.filter((e) => e.date < "2024-01-25"),
-        input,
       );
 
       expect(result.creates.length).toBe(2);
       expect(result.idsToDelete.length).toBe(0);
-      expect(result.updates.length).toBe(0);
 
       expect(result.creates).toContainEqual({
         date: "2024-01-25",
@@ -324,22 +572,16 @@ describe("transformer", () => {
     });
 
     test("overwrite complete workweek with vacation should produce expected delta", () => {
-      const weekDays = getTestWeekdays();
       const categoryMapping = getTestTagToCategoryMappings();
 
       // The complete average workweek scenario
-      const input = convertToTimeTableInput(
-        weekDays,
+      const input = mapToTimeTableEntries(
+        getTestDateRange(),
         categoryMapping,
         getVacationWeekEntries(),
       );
 
-      const result = getNokoCallsForDelta(
-        weekDays,
-        categoryMapping,
-        getAverageWorkweekEntries(),
-        input,
-      );
+      const result = getNokoCallsForDelta(input, getAverageWorkweekEntries());
 
       expect(result.idsToDelete.length).toBe(6);
       expect(result.idsToDelete).toContain(5001);
@@ -348,8 +590,6 @@ describe("transformer", () => {
       expect(result.idsToDelete).toContain(5004);
       expect(result.idsToDelete).toContain(5005);
       expect(result.idsToDelete).toContain(5006);
-
-      expect(result.updates.length).toBe(0);
 
       expect(result.creates.length).toBe(5);
       expect(result.creates).toContainEqual({
@@ -385,18 +625,16 @@ describe("transformer", () => {
     });
 
     test("update workweek to complete workweek should produce expected delta", () => {
-      const weekDays = getTestWeekdays();
       const categoryMapping = getTestTagToCategoryMappings();
 
-      const input = convertToTimeTableInput(
-        weekDays,
+      const input = mapToTimeTableEntries(
+        getTestDateRange(),
         categoryMapping,
         getAverageWorkweekEntries(),
       );
 
       const result = getNokoCallsForDelta(
-        weekDays,
-        categoryMapping,
+        input,
         // All average workweek devlopment entry minutes halved scenario
         getAverageWorkweekEntries().map((e) => {
           if (e.description === "#Development") {
@@ -404,83 +642,58 @@ describe("transformer", () => {
           }
           return e;
         }),
-        input,
       );
 
-      expect(result.creates.length).toBe(0);
-      expect(result.idsToDelete.length).toBe(0);
-      expect(result.updates.length).toBe(4);
+      expect(result.creates.length).toBe(4);
+      expect(result.creates).toContainEqual({
+        date: "2024-01-22",
+        minutes: 480,
+        project_id: 1,
+        description: "#Development",
+      });
+      expect(result.creates).toContainEqual({
+        date: "2024-01-23",
+        minutes: 480,
+        project_id: 1,
+        description: "#Development",
+      });
+      expect(result.creates).toContainEqual({
+        date: "2024-01-24",
+        minutes: 420,
+        project_id: 1,
+        description: "#Development",
+      });
+      expect(result.creates).toContainEqual({
+        date: "2024-01-26",
+        minutes: 480,
+        project_id: 1,
+        description: "#Development",
+      });
 
-      expect(result.updates).toContainEqual({
-        id: 5001,
-        body: {
-          date: "2024-01-22",
-          minutes: 480,
-          project_id: 1,
-          description: "#Development",
-        },
-      });
-      expect(result.updates).toContainEqual({
-        id: 5002,
-        body: {
-          date: "2024-01-23",
-          minutes: 480,
-          project_id: 1,
-          description: "#Development",
-        },
-      });
-      expect(result.updates).toContainEqual({
-        id: 5003,
-        body: {
-          date: "2024-01-24",
-          minutes: 420,
-          project_id: 1,
-          description: "#Development",
-        },
-      });
-      expect(result.updates).toContainEqual({
-        id: 5006,
-        body: {
-          date: "2024-01-26",
-          minutes: 480,
-          project_id: 1,
-          description: "#Development",
-        },
-      });
+      expect(result.idsToDelete.length).toBe(4);
+      expect(result.idsToDelete).toContain(5001);
+      expect(result.idsToDelete).toContain(5002);
+      expect(result.idsToDelete).toContain(5003);
+      expect(result.idsToDelete).toContain(5006);
     });
 
-    test("ignores unmapped entries", () => {
-      const input: TimeTableEntry[] = [
-        { category: "Developments", day: "maandag", minutes: 480 },
-        { category: "Developmen", day: "maandag", minutes: 480 },
-      ];
-      const result = getNokoCallsForDelta(
-        getTestWeekdays(),
-        getTestTagToCategoryMappings(),
-        [],
-        input,
-      );
-
-      expect(result.creates.length).toBe(0);
-      expect(result.idsToDelete.length).toBe(0);
-      expect(result.updates.length).toBe(0);
-    });
-
-    test("ignores archived categories", () => {
-      const weekDays = getTestWeekdays();
+    test("ignores readonly categories", () => {
       const categoryMapping = getTestTagToCategoryMappings();
-      categoryMapping[2].archived = true;
-      categoryMapping[3].archived = true;
+      categoryMapping[2].readonly = true;
+      categoryMapping[3].readonly = true;
       const entries = getAverageWorkweekEntries();
 
       // The complete average workweek scenario
-      const input = convertToTimeTableInput(weekDays, categoryMapping, entries);
+      const input = mapToTimeTableEntries(
+        getTestDateRange(),
+        categoryMapping,
+        entries,
+      );
 
-      const result = getNokoCallsForDelta(weekDays, categoryMapping, [], input);
+      const result = getNokoCallsForDelta(input, []);
 
       expect(result.creates.length).toBe(4);
       expect(result.idsToDelete.length).toBe(0);
-      expect(result.updates.length).toBe(0);
 
       expect(result.creates).toContainEqual({
         date: "2024-01-22",
@@ -664,32 +877,40 @@ function getTestWeekdays(): Date[] {
   ];
 }
 
-function getTestTagToCategoryMappings(): TagToCategoryMapping[] {
+function getTestDateRange(): DateRange {
+  return {
+    dates: getTestWeekdays(),
+    weekNumber: 4,
+    year: 2024,
+  };
+}
+
+function getTestTagToCategoryMappings(): Category[] {
   return [
     {
       order: 1,
-      archived: false,
+      readonly: false,
       name: "Development",
       projectId: 1,
       nokoTags: ["#Development"],
     },
     {
       order: 2,
-      archived: false,
+      readonly: false,
       name: "Vacation",
       projectId: 3,
       nokoTags: ["#Vacation"],
     },
     {
       order: 3,
-      archived: false,
+      readonly: false,
       name: "National holiday",
       projectId: 2,
       nokoTags: ["#National-Holiday"],
     },
     {
       order: 4,
-      archived: false,
+      readonly: false,
       name: "Presentation",
       projectId: 1,
       nokoTags: ["#Presentation"],

--- a/test/transformer.test.ts
+++ b/test/transformer.test.ts
@@ -720,6 +720,57 @@ describe("transformer", () => {
         description: "#Development",
       });
     });
+
+    test("ignores categories without a project ID or Noko tags", () => {
+      const categoryMapping = getTestTagToCategoryMappings();
+      categoryMapping[2].readonly = true;
+      categoryMapping[3].readonly = true;
+      const entries = getAverageWorkweekEntries();
+
+      // The complete average workweek scenario
+      const input = mapToTimeTableEntries(
+        getTestDateRange(),
+        categoryMapping,
+        entries,
+      );
+      input.forEach((entry) => {
+        if (entry.category.name === categoryMapping[2].name) {
+          entry.category.projectId = undefined;
+        } else if (entry.category.name === categoryMapping[3].name) {
+          entry.category.nokoTags = undefined;
+        }
+      });
+
+      const result = getNokoCallsForDelta(input, []);
+
+      expect(result.creates.length).toBe(4);
+      expect(result.idsToDelete.length).toBe(0);
+
+      expect(result.creates).toContainEqual({
+        date: "2024-01-22",
+        minutes: 480,
+        project_id: 1,
+        description: "#Development",
+      });
+      expect(result.creates).toContainEqual({
+        date: "2024-01-23",
+        minutes: 480,
+        project_id: 1,
+        description: "#Development",
+      });
+      expect(result.creates).toContainEqual({
+        date: "2024-01-24",
+        minutes: 420,
+        project_id: 1,
+        description: "#Development",
+      });
+      expect(result.creates).toContainEqual({
+        date: "2024-01-26",
+        minutes: 480,
+        project_id: 1,
+        description: "#Development",
+      });
+    });
   });
 });
 

--- a/test/transformer.test.ts
+++ b/test/transformer.test.ts
@@ -23,7 +23,7 @@ describe("transformer", () => {
             weekNumber: 4,
             year: 2024,
           },
-          getTestTagToCategoryMappings(),
+          getTestCategories(),
           [],
         ),
       ).toThrowError(
@@ -46,7 +46,7 @@ describe("transformer", () => {
             weekNumber: 4,
             year: 2024,
           },
-          getTestTagToCategoryMappings(),
+          getTestCategories(),
           [],
         ),
       ).toThrowError(
@@ -70,7 +70,7 @@ describe("transformer", () => {
             weekNumber: 4,
             year: 2024,
           },
-          getTestTagToCategoryMappings(),
+          getTestCategories(),
           [],
         ),
       ).toThrowError(
@@ -81,7 +81,7 @@ describe("transformer", () => {
     test("entries should be sorted by category input order then by date ascending", () => {
       const result = mapToTimeTableEntries(
         getTestDateRange(),
-        getTestTagToCategoryMappings(),
+        getTestCategories(),
         [
           {
             id: 5004,
@@ -176,141 +176,180 @@ describe("transformer", () => {
         ],
       );
 
-      expect(result.length).toBe(28);
+      expect(result.entries.length).toBe(28);
+      expect(result.unmappedEntries.length).toBe(0);
 
-      expect(result[0].category.name).toBe("Development");
-      expect(result[1].category.name).toBe("Development");
-      expect(result[2].category.name).toBe("Development");
-      expect(result[3].category.name).toBe("Development");
-      expect(result[4].category.name).toBe("Development");
-      expect(result[5].category.name).toBe("Development");
-      expect(result[6].category.name).toBe("Development");
+      expect(result.entries[0].category.name).toBe("Development");
+      expect(result.entries[1].category.name).toBe("Development");
+      expect(result.entries[2].category.name).toBe("Development");
+      expect(result.entries[3].category.name).toBe("Development");
+      expect(result.entries[4].category.name).toBe("Development");
+      expect(result.entries[5].category.name).toBe("Development");
+      expect(result.entries[6].category.name).toBe("Development");
 
-      expect(result[7].category.name).toBe("Vacation");
-      expect(result[8].category.name).toBe("Vacation");
-      expect(result[9].category.name).toBe("Vacation");
-      expect(result[10].category.name).toBe("Vacation");
-      expect(result[11].category.name).toBe("Vacation");
-      expect(result[12].category.name).toBe("Vacation");
-      expect(result[13].category.name).toBe("Vacation");
+      expect(result.entries[7].category.name).toBe("Vacation");
+      expect(result.entries[8].category.name).toBe("Vacation");
+      expect(result.entries[9].category.name).toBe("Vacation");
+      expect(result.entries[10].category.name).toBe("Vacation");
+      expect(result.entries[11].category.name).toBe("Vacation");
+      expect(result.entries[12].category.name).toBe("Vacation");
+      expect(result.entries[13].category.name).toBe("Vacation");
 
-      expect(result[14].category.name).toBe("National holiday");
-      expect(result[15].category.name).toBe("National holiday");
-      expect(result[16].category.name).toBe("National holiday");
-      expect(result[17].category.name).toBe("National holiday");
-      expect(result[18].category.name).toBe("National holiday");
-      expect(result[19].category.name).toBe("National holiday");
-      expect(result[20].category.name).toBe("National holiday");
+      expect(result.entries[14].category.name).toBe("National holiday");
+      expect(result.entries[15].category.name).toBe("National holiday");
+      expect(result.entries[16].category.name).toBe("National holiday");
+      expect(result.entries[17].category.name).toBe("National holiday");
+      expect(result.entries[18].category.name).toBe("National holiday");
+      expect(result.entries[19].category.name).toBe("National holiday");
+      expect(result.entries[20].category.name).toBe("National holiday");
 
-      expect(result[21].category.name).toBe("Presentation");
-      expect(result[22].category.name).toBe("Presentation");
-      expect(result[23].category.name).toBe("Presentation");
-      expect(result[24].category.name).toBe("Presentation");
-      expect(result[25].category.name).toBe("Presentation");
-      expect(result[26].category.name).toBe("Presentation");
-      expect(result[27].category.name).toBe("Presentation");
+      expect(result.entries[21].category.name).toBe("Presentation");
+      expect(result.entries[22].category.name).toBe("Presentation");
+      expect(result.entries[23].category.name).toBe("Presentation");
+      expect(result.entries[24].category.name).toBe("Presentation");
+      expect(result.entries[25].category.name).toBe("Presentation");
+      expect(result.entries[26].category.name).toBe("Presentation");
+      expect(result.entries[27].category.name).toBe("Presentation");
 
-      expect(toShortIsoDate(result[0].date)).toBe("2024-01-22");
-      expect(toShortIsoDate(result[7].date)).toBe("2024-01-22");
-      expect(toShortIsoDate(result[14].date)).toBe("2024-01-22");
-      expect(toShortIsoDate(result[21].date)).toBe("2024-01-22");
+      expect(toShortIsoDate(result.entries[0].date)).toBe("2024-01-22");
+      expect(toShortIsoDate(result.entries[7].date)).toBe("2024-01-22");
+      expect(toShortIsoDate(result.entries[14].date)).toBe("2024-01-22");
+      expect(toShortIsoDate(result.entries[21].date)).toBe("2024-01-22");
 
-      expect(toShortIsoDate(result[1].date)).toBe("2024-01-23");
-      expect(toShortIsoDate(result[8].date)).toBe("2024-01-23");
-      expect(toShortIsoDate(result[15].date)).toBe("2024-01-23");
-      expect(toShortIsoDate(result[22].date)).toBe("2024-01-23");
+      expect(toShortIsoDate(result.entries[1].date)).toBe("2024-01-23");
+      expect(toShortIsoDate(result.entries[8].date)).toBe("2024-01-23");
+      expect(toShortIsoDate(result.entries[15].date)).toBe("2024-01-23");
+      expect(toShortIsoDate(result.entries[22].date)).toBe("2024-01-23");
 
-      expect(toShortIsoDate(result[2].date)).toBe("2024-01-24");
-      expect(toShortIsoDate(result[9].date)).toBe("2024-01-24");
-      expect(toShortIsoDate(result[16].date)).toBe("2024-01-24");
-      expect(toShortIsoDate(result[23].date)).toBe("2024-01-24");
+      expect(toShortIsoDate(result.entries[2].date)).toBe("2024-01-24");
+      expect(toShortIsoDate(result.entries[9].date)).toBe("2024-01-24");
+      expect(toShortIsoDate(result.entries[16].date)).toBe("2024-01-24");
+      expect(toShortIsoDate(result.entries[23].date)).toBe("2024-01-24");
 
-      expect(toShortIsoDate(result[3].date)).toBe("2024-01-25");
-      expect(toShortIsoDate(result[10].date)).toBe("2024-01-25");
-      expect(toShortIsoDate(result[17].date)).toBe("2024-01-25");
-      expect(toShortIsoDate(result[24].date)).toBe("2024-01-25");
+      expect(toShortIsoDate(result.entries[3].date)).toBe("2024-01-25");
+      expect(toShortIsoDate(result.entries[10].date)).toBe("2024-01-25");
+      expect(toShortIsoDate(result.entries[17].date)).toBe("2024-01-25");
+      expect(toShortIsoDate(result.entries[24].date)).toBe("2024-01-25");
 
-      expect(toShortIsoDate(result[4].date)).toBe("2024-01-26");
-      expect(toShortIsoDate(result[11].date)).toBe("2024-01-26");
-      expect(toShortIsoDate(result[18].date)).toBe("2024-01-26");
-      expect(toShortIsoDate(result[25].date)).toBe("2024-01-26");
+      expect(toShortIsoDate(result.entries[4].date)).toBe("2024-01-26");
+      expect(toShortIsoDate(result.entries[11].date)).toBe("2024-01-26");
+      expect(toShortIsoDate(result.entries[18].date)).toBe("2024-01-26");
+      expect(toShortIsoDate(result.entries[25].date)).toBe("2024-01-26");
 
-      expect(toShortIsoDate(result[5].date)).toBe("2024-01-27");
-      expect(toShortIsoDate(result[12].date)).toBe("2024-01-27");
-      expect(toShortIsoDate(result[19].date)).toBe("2024-01-27");
-      expect(toShortIsoDate(result[26].date)).toBe("2024-01-27");
+      expect(toShortIsoDate(result.entries[5].date)).toBe("2024-01-27");
+      expect(toShortIsoDate(result.entries[12].date)).toBe("2024-01-27");
+      expect(toShortIsoDate(result.entries[19].date)).toBe("2024-01-27");
+      expect(toShortIsoDate(result.entries[26].date)).toBe("2024-01-27");
 
-      expect(toShortIsoDate(result[6].date)).toBe("2024-01-28");
-      expect(toShortIsoDate(result[13].date)).toBe("2024-01-28");
-      expect(toShortIsoDate(result[20].date)).toBe("2024-01-28");
-      expect(toShortIsoDate(result[27].date)).toBe("2024-01-28");
+      expect(toShortIsoDate(result.entries[6].date)).toBe("2024-01-28");
+      expect(toShortIsoDate(result.entries[13].date)).toBe("2024-01-28");
+      expect(toShortIsoDate(result.entries[20].date)).toBe("2024-01-28");
+      expect(toShortIsoDate(result.entries[27].date)).toBe("2024-01-28");
     });
 
     test("average workweek scenario should be mapped correctly", () => {
       const result = mapToTimeTableEntries(
         getTestDateRange(),
-        getTestTagToCategoryMappings(),
+        getTestCategories(),
         getAverageWorkweekEntries(),
       );
 
-      expect(result.length).toBe(28);
+      expect(result.entries.length).toBe(28);
+      expect(result.unmappedEntries.length).toBe(0);
 
       expectToHaveTimeTableEntriesForProjectWeekDays(
         "Development",
-        result,
+        result.entries,
         [480, 480, 420, 0, 480, 0, 0],
       );
 
       expectToHaveTimeTableEntriesForProjectWeekDays(
         "Presentation",
-        result,
+        result.entries,
         [0, 0, 60, 0, 0, 0, 0],
       );
 
       expectToHaveTimeTableEntriesForProjectWeekDays(
         "National holiday",
-        result,
+        result.entries,
         [0, 0, 0, 480, 0, 0, 0],
       );
 
       expectToHaveTimeTableEntriesForProjectWeekDays(
         "Vacation",
-        result,
+        result.entries,
         [0, 0, 0, 0, 0, 0, 0],
+      );
+    });
+
+    test("average workweek scenario with unmapped entries should be mapped correctly", () => {
+      // Remove the categories National holiday and Presentation
+      const testCategories = getTestCategories().slice(0, 2);
+
+      const result = mapToTimeTableEntries(
+        getTestDateRange(),
+        testCategories,
+        getAverageWorkweekEntries(),
+      );
+
+      //                  | Monday | Tuesday | Wednesday | Thursday | Friday
+      // Development      | 8h     | 8h      | 7h        | -        | 8h
+      // Presentation     | -      | -       | 1h        | -        | -
+      // National holiday | -      | -       | -         | 8h       | -
+      expect(result.entries.length).toBe(14);
+      expect(result.unmappedEntries.length).toBe(7);
+
+      expectToHaveTimeTableEntriesForProjectWeekDays(
+        "Development",
+        result.entries,
+        [480, 480, 420, 0, 480, 0, 0],
+      );
+
+      expectToHaveTimeTableEntriesForProjectWeekDays(
+        "Vacation",
+        result.entries,
+        [0, 0, 0, 0, 0, 0, 0],
+      );
+
+      expectToHaveTimeTableEntriesForProjectWeekDays(
+        "Unmapped",
+        result.unmappedEntries,
+        [0, 0, 60, 480, 0, 0, 0],
       );
     });
 
     test("partial average workweek scenario should be mapped correctly", () => {
       const result = mapToTimeTableEntries(
         getTestDateRange(),
-        getTestTagToCategoryMappings(),
+        getTestCategories(),
         // Only include monday until wednesday
         getAverageWorkweekEntries().filter((e) => e.date < "2024-01-25"),
       );
 
-      expect(result.length).toBe(28);
+      expect(result.entries.length).toBe(28);
+      expect(result.unmappedEntries.length).toBe(0);
 
       expectToHaveTimeTableEntriesForProjectWeekDays(
         "Development",
-        result,
+        result.entries,
         [480, 480, 420, 0, 0, 0, 0],
       );
 
       expectToHaveTimeTableEntriesForProjectWeekDays(
         "Presentation",
-        result,
+        result.entries,
         [0, 0, 60, 0, 0, 0, 0],
       );
 
       expectToHaveTimeTableEntriesForProjectWeekDays(
         "National holiday",
-        result,
+        result.entries,
         [0, 0, 0, 0, 0, 0, 0],
       );
 
       expectToHaveTimeTableEntriesForProjectWeekDays(
         "Vacation",
-        result,
+        result.entries,
         [0, 0, 0, 0, 0, 0, 0],
       );
     });
@@ -318,33 +357,34 @@ describe("transformer", () => {
     test("vacation scenario should be mapped correctly", () => {
       const result = mapToTimeTableEntries(
         getTestDateRange(),
-        getTestTagToCategoryMappings(),
+        getTestCategories(),
         getVacationWeekEntries(),
       );
 
-      expect(result.length).toBe(28);
+      expect(result.entries.length).toBe(28);
+      expect(result.unmappedEntries.length).toBe(0);
 
       expectToHaveTimeTableEntriesForProjectWeekDays(
         "Development",
-        result,
+        result.entries,
         [0, 0, 0, 0, 0, 0, 0],
       );
 
       expectToHaveTimeTableEntriesForProjectWeekDays(
         "Presentation",
-        result,
+        result.entries,
         [0, 0, 0, 0, 0, 0, 0],
       );
 
       expectToHaveTimeTableEntriesForProjectWeekDays(
         "National holiday",
-        result,
+        result.entries,
         [0, 0, 0, 0, 0, 0, 0],
       );
 
       expectToHaveTimeTableEntriesForProjectWeekDays(
         "Vacation",
-        result,
+        result.entries,
         [480, 480, 480, 480, 480, 0, 0],
       );
     });
@@ -352,7 +392,7 @@ describe("transformer", () => {
     test("ignores unmapped entries", () => {
       const result = mapToTimeTableEntries(
         getTestDateRange(),
-        getTestTagToCategoryMappings(),
+        getTestCategories(),
         [
           {
             id: 5001,
@@ -416,29 +456,30 @@ describe("transformer", () => {
         ],
       );
 
-      expect(result.length).toBe(28);
+      expect(result.entries.length).toBe(28);
+      expect(result.unmappedEntries.length).toBeGreaterThan(0);
 
       expectToHaveTimeTableEntriesForProjectWeekDays(
         "Development",
-        result,
+        result.entries,
         [0, 0, 0, 0, 0, 0, 0],
       );
 
       expectToHaveTimeTableEntriesForProjectWeekDays(
         "Presentation",
-        result,
+        result.entries,
         [0, 0, 0, 0, 0, 0, 0],
       );
 
       expectToHaveTimeTableEntriesForProjectWeekDays(
         "National holiday",
-        result,
+        result.entries,
         [0, 0, 0, 0, 0, 0, 0],
       );
 
       expectToHaveTimeTableEntriesForProjectWeekDays(
         "Vacation",
-        result,
+        result.entries,
         [0, 0, 0, 0, 0, 0, 0],
       );
     });
@@ -484,7 +525,7 @@ describe("transformer", () => {
   // tests pass as it is used to create scenarios as input for these tests
   describe("getNokoCallsForDelta", () => {
     test("empty workweek to complete workweek should produce expected delta", () => {
-      const categoryMapping = getTestTagToCategoryMappings();
+      const categoryMapping = getTestCategories();
       const entries = getAverageWorkweekEntries();
 
       // The complete average workweek scenario
@@ -494,7 +535,7 @@ describe("transformer", () => {
         entries,
       );
 
-      const result = getNokoCallsForDelta(input, []);
+      const result = getNokoCallsForDelta(input.entries, []);
 
       expect(result.creates.length).toBe(6);
       expect(result.idsToDelete.length).toBe(0);
@@ -538,7 +579,7 @@ describe("transformer", () => {
     });
 
     test("partial workweek to complete workweek should produce expected delta", () => {
-      const categoryMapping = getTestTagToCategoryMappings();
+      const categoryMapping = getTestCategories();
       const entries = getAverageWorkweekEntries();
 
       // The complete average workweek scenario
@@ -549,7 +590,7 @@ describe("transformer", () => {
       );
 
       const result = getNokoCallsForDelta(
-        input,
+        input.entries,
         // Only include monday until wednesday
         entries.filter((e) => e.date < "2024-01-25"),
       );
@@ -572,7 +613,7 @@ describe("transformer", () => {
     });
 
     test("overwrite complete workweek with vacation should produce expected delta", () => {
-      const categoryMapping = getTestTagToCategoryMappings();
+      const categoryMapping = getTestCategories();
 
       // The complete average workweek scenario
       const input = mapToTimeTableEntries(
@@ -581,7 +622,10 @@ describe("transformer", () => {
         getVacationWeekEntries(),
       );
 
-      const result = getNokoCallsForDelta(input, getAverageWorkweekEntries());
+      const result = getNokoCallsForDelta(
+        input.entries,
+        getAverageWorkweekEntries(),
+      );
 
       expect(result.idsToDelete.length).toBe(6);
       expect(result.idsToDelete).toContain(5001);
@@ -625,7 +669,7 @@ describe("transformer", () => {
     });
 
     test("update workweek to complete workweek should produce expected delta", () => {
-      const categoryMapping = getTestTagToCategoryMappings();
+      const categoryMapping = getTestCategories();
 
       const input = mapToTimeTableEntries(
         getTestDateRange(),
@@ -634,7 +678,7 @@ describe("transformer", () => {
       );
 
       const result = getNokoCallsForDelta(
-        input,
+        input.entries,
         // All average workweek devlopment entry minutes halved scenario
         getAverageWorkweekEntries().map((e) => {
           if (e.description === "#Development") {
@@ -678,7 +722,7 @@ describe("transformer", () => {
     });
 
     test("ignores readonly categories", () => {
-      const categoryMapping = getTestTagToCategoryMappings();
+      const categoryMapping = getTestCategories();
       categoryMapping[2].readonly = true;
       categoryMapping[3].readonly = true;
       const entries = getAverageWorkweekEntries();
@@ -690,7 +734,7 @@ describe("transformer", () => {
         entries,
       );
 
-      const result = getNokoCallsForDelta(input, []);
+      const result = getNokoCallsForDelta(input.entries, []);
 
       expect(result.creates.length).toBe(4);
       expect(result.idsToDelete.length).toBe(0);
@@ -722,7 +766,7 @@ describe("transformer", () => {
     });
 
     test("ignores categories without a project ID or Noko tags", () => {
-      const categoryMapping = getTestTagToCategoryMappings();
+      const categoryMapping = getTestCategories();
       categoryMapping[2].readonly = true;
       categoryMapping[3].readonly = true;
       const entries = getAverageWorkweekEntries();
@@ -733,7 +777,7 @@ describe("transformer", () => {
         categoryMapping,
         entries,
       );
-      input.forEach((entry) => {
+      input.entries.forEach((entry) => {
         if (entry.category.name === categoryMapping[2].name) {
           entry.category.projectId = undefined;
         } else if (entry.category.name === categoryMapping[3].name) {
@@ -741,7 +785,7 @@ describe("transformer", () => {
         }
       });
 
-      const result = getNokoCallsForDelta(input, []);
+      const result = getNokoCallsForDelta(input.entries, []);
 
       expect(result.creates.length).toBe(4);
       expect(result.idsToDelete.length).toBe(0);
@@ -936,7 +980,7 @@ function getTestDateRange(): DateRange {
   };
 }
 
-function getTestTagToCategoryMappings(): Category[] {
+function getTestCategories(): Category[] {
   return [
     {
       order: 1,


### PR DESCRIPTION
Changes
- local storage model of categories field rename of archived to readonly
- left and right arrow key navigation has been removed since it made editing existing input a chore. Use tab and shift+tab instead.
- unmapped Noko entries are now shown, if present, as a readonly row in the week editor