### PR TITLE
Remove project participants

### DIFF
--- a/src/noko-client.ts
+++ b/src/noko-client.ts
@@ -96,7 +96,7 @@ export default class NokoClient {
     return await response.json();
   }
 
-  public async getProjects(): Promise<INokoGetProjectResponse[]> {
+  public async getEnabledProjects(): Promise<INokoGetProjectResponse[]> {
     const options = this.getBaseRequestOptions();
     options.method = "GET";
 

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -249,7 +249,6 @@ export interface INokoGetProjectResponse {
   id: number;
   name: string;
   enabled: boolean;
-  participants: { id: number }[];
 }
 
 // See https://developer.nokotime.com/v2/current_user/

--- a/src/store/application-store.ts
+++ b/src/store/application-store.ts
@@ -289,14 +289,12 @@ function tryParseStoredNokoProjects(json: string): INokoGetProjectResponse[] {
       "id" in candidate &&
       typeof candidate.id === "number" &&
       "name" in candidate &&
-      typeof candidate.name === "string" &&
-      "enabled" in candidate &&
-      typeof candidate.enabled === "boolean"
+      typeof candidate.name === "string"
     ) {
       results.push({
         id: candidate.id,
         name: candidate.name,
-        enabled: candidate.enabled
+        enabled: true
       });
     } else {
       console.debug("Stored tag to category mapping is not valid", candidate);

--- a/src/store/application-store.ts
+++ b/src/store/application-store.ts
@@ -144,7 +144,7 @@ export const useApplicationStore = defineStore("application", {
           return tryParseStoredNokoProjects(cachedJson);
         }
 
-        const nokoProjects = await this.getNokoClient().getProjects();
+        const nokoProjects = await this.getNokoClient().getEnabledProjects();
         localStorage.setItem(
           nokoProjectCacheStorageKey,
           JSON.stringify(nokoProjects),
@@ -291,23 +291,12 @@ function tryParseStoredNokoProjects(json: string): INokoGetProjectResponse[] {
       "name" in candidate &&
       typeof candidate.name === "string" &&
       "enabled" in candidate &&
-      typeof candidate.enabled === "boolean" &&
-      "participants" in candidate &&
-      Array.isArray(candidate.participants) &&
-      (candidate.participants as unknown[]).length > 0 &&
-      (candidate.participants as unknown[]).every(
-        (e) =>
-          e != null &&
-          typeof e === "object" &&
-          "id" in e &&
-          typeof e.id === "number",
-      )
+      typeof candidate.enabled === "boolean"
     ) {
       results.push({
         id: candidate.id,
         name: candidate.name,
-        enabled: candidate.enabled,
-        participants: candidate.participants,
+        enabled: candidate.enabled
       });
     } else {
       console.debug("Stored tag to category mapping is not valid", candidate);

--- a/src/views/SetupCategories.vue
+++ b/src/views/SetupCategories.vue
@@ -23,9 +23,9 @@ const router = useRouter();
 const applicationStore = useApplicationStore();
 
 const loadProjects = async (refreshCache: boolean) => {
-  return (await applicationStore.getCachedNokoProjects(refreshCache))
-    .filter((p) => p.enabled)
-    .map((p) => ({ id: p.id, name: p.name }));
+  return (await applicationStore.getCachedNokoProjects(refreshCache)).map(
+    (p) => ({ id: p.id, name: p.name }),
+  );
 };
 
 const loadTags = async (refreshCache: boolean) => {

--- a/src/views/SetupCategories.vue
+++ b/src/views/SetupCategories.vue
@@ -24,11 +24,7 @@ const applicationStore = useApplicationStore();
 
 const loadProjects = async (refreshCache: boolean) => {
   return (await applicationStore.getCachedNokoProjects(refreshCache))
-    .filter(
-      (p) =>
-        p.enabled &&
-        p.participants.some((p) => p.id === applicationStore.nokoUser?.id),
-    )
+    .filter((p) => p.enabled)
     .map((p) => ({ id: p.id, name: p.name }));
 };
 


### PR DESCRIPTION
The Noko API returns participants per project, but they seem to be irrelevant whether the user can make entries for said project.

The participants returned were not up to date and it was not clear how to configure this properly in Noko. The easy solution was to simply remove the participant filtering functionality from Keepi.